### PR TITLE
fix unicode unescaping in JSON

### DIFF
--- a/lib/crack/json.rb
+++ b/lib/crack/json.rb
@@ -16,7 +16,7 @@ module Crack
 
     protected
       def self.unescape(str)
-        str.gsub(/\\u([0-9a-f]{4})/) { [$1.hex].pack("U") }
+        str.gsub(/\\[u|U]([0-9a-fA-F]{4})/) { [$1.hex].pack("U") }
       end
       
       # matches YAML-formatted dates

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -4,6 +4,7 @@ require 'test_helper'
 class JsonTest < Test::Unit::TestCase  
   TESTS = {
     %q({"data": "G\u00fcnter"})                   => {"data" => "Günter"},
+		%q({"html": "\u003Cdiv\\u003E"})              => {"html" => "<div>"},
     %q({"returnTo":{"\/categories":"\/"}})        => {"returnTo" => {"/categories" => "/"}},
     %q({returnTo:{"\/categories":"\/"}})          => {"returnTo" => {"/categories" => "/"}},
     %q({"return\\"To\\":":{"\/categories":"\/"}}) => {"return\"To\":" => {"/categories" => "/"}},


### PR DESCRIPTION
Case-insensitive match on \u escape sequences. Some json generators apparently use A-F instead of a-f for the hex. Added a test for this which now passes.
