### PR TITLE
Add optional test for psych parser and fix for psych parsing error.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,14 @@ Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/*_test.rb'
   test.verbose = false
+
+  begin
+    require 'psych'
+  rescue ::LoadError
+    puts('Psych not installed, skipping psych tests.')
+    test.test_files = FileList[test.pattern].exclude('test/psych_json_test.rb')
+    test.pattern = nil
+  end
 end
 
 task :default => :test

--- a/lib/crack/json.rb
+++ b/lib/crack/json.rb
@@ -10,7 +10,7 @@ module Crack
   class JSON
     def self.parse(json)
       YAML.load(unescape(convert_json_to_yaml(json)))
-    rescue ArgumentError => e
+    rescue ArgumentError, SyntaxError => e
       raise ParseError, "Invalid JSON string"
     end
 

--- a/test/psych_json_test.rb
+++ b/test/psych_json_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'yaml'
+
+class PsychJsonTest < Test::Unit::TestCase
+  def setup
+    @original_yamler = YAML::ENGINE.yamler
+    YAML::ENGINE.yamler = 'psych'
+  end
+
+  should "raise error for failed decoding" do
+    lambda {
+      Crack::JSON.parse(%({: 1}))
+    }.should raise_error(Crack::ParseError)
+  end
+
+  def teardown
+    YAML::ENGINE.yamler = @original_yamler
+  end
+end


### PR DESCRIPTION
When using the Crack gem with ruby 1.9.2 you may see Psych::Syntax errors bubble up through the gem (see issue 29 https://github.com/jnunemaker/crack/issues/29) and to the calling code. This pull request attempts to demonstrate that issue via a psych test (which is only executed when your machine is configured to support psych) and a potential fix for that issue.

When you build ruby 1.9.2 with libyaml on your system ruby automatically includes the psych YAML parser as the default instead of syck which is used in previous versions of ruby (and those machines building ruby without libyaml). The error bubbled up from syck when bogus YAML is provided, which crack catches and wraps, is an argument error. The error bubbled up from psych is a derivative of the SyntaxError type.

So the fix was to catch both error types since the syck parser is currently in use and needs to be supported at least for a while but it is no longer being maintained and presumably will not be used by default in some future release of ruby.
