### PR TITLE
Exception from the special treatment of XML tags with type == file

### DIFF
--- a/lib/crack/xml.rb
+++ b/lib/crack/xml.rb
@@ -70,7 +70,8 @@ class REXMLUtilityNode #:nodoc:
   end
 
   def to_hash
-    if @type == "file"
+    # ACG: Added a check here to prevent an exception a type == "file" tag has nodes within it
+    if @type == "file" and (@children.first.nil? or @children.first.is_a?(String))
       f = StringIO.new((@children.first || '').unpack('m').first)
       class << f
         attr_accessor :original_filename, :content_type

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -496,4 +496,16 @@ class XmlTest < Test::Unit::TestCase
   should "handle an xml string containing a single space" do
     Crack::XML.parse(' ').should == {}
   end
+
+  should "handle a node with type == file that has children" do
+    # Example is an excerpt from a problematic kvm domain config file
+    example_xml = <<-EOT
+    <disk type='file' device='cdrom'>
+      <driver name='qemu' type='raw' cache='none' io='native'/>
+      <source file='/tmp/cdrom.iso'/>
+    </disk>
+    EOT
+
+    Crack::XML.parse(example_xml).should == {"disk"=>{"driver"=>{"name"=>"qemu", "type"=>"raw", "cache"=>"none", "io"=>"native"}, "source"=>{"file"=>"/tmp/cdrom.iso"}, "type"=>"file", "device"=>"cdrom"}}
+  end
 end


### PR DESCRIPTION
I was parsing an XML document (in this case, the XML configuration of a kvm domain) with Crack::XML.parse and it was throwing an exception. 

After digging around this was because in the case where the tag has a type attribute set to file the children nodes are assumed to be strings. In this case the children are another XML tag and not a string causing an exception.

I also added a test as requested covering this bug.
