### PR TITLE
Need to require 'rexml/document'

### DIFF
--- a/lib/crack/xml.rb
+++ b/lib/crack/xml.rb
@@ -2,6 +2,7 @@ require 'rexml/parsers/streamparser'
 require 'rexml/parsers/baseparser'
 require 'rexml/light/node'
 require 'rexml/text'
+require "rexml/document"
 require 'date'
 require 'time'
 require 'yaml'


### PR DESCRIPTION
Fix parsing errors of unnormalized characters on Ruby 1.9.3-p392

e.g., &amp;
