### PR TITLE
Bump safe_yaml dependency "~> 0.9.0" -> "~> 1.0.0"

### DIFF
--- a/crack.gemspec
+++ b/crack.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.version       = Crack::VERSION
   gem.license       = "MIT"
 
-  gem.add_dependency "safe_yaml", "~> 0.9.0"
+  gem.add_dependency "safe_yaml", "~> 1.0.0"
 end


### PR DESCRIPTION
Version 1.0.0 of safe_yaml was released on December 27, 2013. In the
absence of an updated changelog, here are the commits included in this
version bump:

  https://github.com/dtao/safe_yaml/compare/8b488914c71d0b267cee752b49a09935a17b5e5f...d25466de3df8a4f1fa8e986f47464db44b3f7d9d
