### PR TITLE
Matchy is not needed anymore.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem "rake"
-gem "jnunemaker-matchy"
 gem "minitest"


### PR DESCRIPTION
It does not look that matchy would be required, since commit 9a994cd05a1ddb. The tests are passing without it for me.
