### PR TITLE
Fix for key mangling when using multiple dates

### DIFF
--- a/lib/crack/json.rb
+++ b/lib/crack/json.rb
@@ -100,7 +100,11 @@ module Crack
         if YAML.constants.include?('Syck')
           (date_starts + date_ends).each { |i| output[i-1] = ' ' }
         else
-          date_starts.each { |i| output[i-2] = '!!timestamp ' }
+          extra_chars_to_be_added = 0
+          date_starts.each do |i|
+            output[i-2+extra_chars_to_be_added] = '!!timestamp '
+            extra_chars_to_be_added += 10
+          end
         end
       end
   end

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -14,6 +14,8 @@ describe "JSON Parsing" do
     %({"a": "'", "b": "5,000"})                   => {"a" => "'", "b" => "5,000"},
     %({"a": "a's, b's and c's", "b": "5,000"})    => {"a" => "a's, b's and c's", "b" => "5,000"},
     %({"a": "2007-01-01"})                        => {'a' => Date.new(2007, 1, 1)},
+    %({"first_date": "2016-01-25", "second_date": "2014-01-26"}) => {'first_date' => Date.new(2016, 1, 25), 'second_date' => Date.new(2014, 1, 26)},
+    %({"first_date": "2016-01-25", "non_date": "Abc", "second_date": "2014-01-26"}) => {'first_date' => Date.new(2016, 1, 25), 'non_date' => 'Abc', 'second_date' => Date.new(2014, 1, 26)},
     %({"a": "2007-01-01 01:12:34 Z"})             => {'a' => Time.utc(2007, 1, 1, 1, 12, 34)},
     # Handle ISO 8601 date/time format http://en.wikipedia.org/wiki/ISO_8601
     %({"a": "2007-01-01T01:12:34Z"})              => {'a' => Time.utc(2007, 1, 1, 1, 12, 34)},


### PR DESCRIPTION
When dates are formatted using the json format_dates method, '!!timestamp ' string gets
inserted into the output string each time a date is encountered. So, the date start index needs
to be updated when a second date is encountered. This should repeat for each date start iteration.

Fixes issue https://github.com/jnunemaker/crack/issues/56