### PR TITLE
Exclude tests (and fixtures) from bundled gem

### DIFF
--- a/crack.gemspec
+++ b/crack.gemspec
@@ -9,8 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://github.com/jnunemaker/crack"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  gem.files         = `git ls-files -- lib/*`.split("\n")
   gem.name          = "crack"
   gem.require_paths = ["lib"]
   gem.version       = Crack::VERSION


### PR DESCRIPTION
First up, thanks for `crack`.

Currently, the bundled gem includes all of cracks tests and fixtures. That makes it quite large (564Kb). There's no need to include those tests and fixtures - this PR removes them from the gemspec (note that the `test_files` attribute is now deprecated, so I've removed that too). The slimmed down gem is 12KB - a 98% size reduction. 🎉 