### PR TITLE
Add REXML to gem dependency

### DIFF
--- a/crack.gemspec
+++ b/crack.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Crack::VERSION
   gem.license       = "MIT"
+
+  gem.add_runtime_dependency("rexml")
 end


### PR DESCRIPTION
## Summary

REXML gem has been bundled gem since Ruby 2.8.0-dev (Ruby 3.0).

- https://bugs.ruby-lang.org/issues/16485
- https://github.com/ruby/ruby/commit/c3ccf23d5807f2ff20127bf5e42df0977bf672fb

This change causes the following error on the Ruby master:

```console
% ruby -v
ruby 2.8.0dev (2020-01-14T00:46:52Z master 440013b2fa) [x86_64-darwin17]
% ./script/test
(snip)

Traceback (most recent call last):
        11: from -e:2:in `<main>'
        10: from -e:2:in `each'
         9: from -e:2:in `block in <main>'
         8: from -e:2:in `load'
         7: from test/xml_test.rb:1:in `<top (required)>'
         6: from test/xml_test.rb:1:in `require'
         5: from
/Users/koic/src/github.com/jnunemaker/crack/test/test_helper.rb:3:in
`<top (required)>'
         4: from
/Users/koic/src/github.com/jnunemaker/crack/test/test_helper.rb:3:in
`require'
         3: from
/Users/koic/src/github.com/jnunemaker/crack/lib/crack.rb:7:in
`<top (required)>'
         2: from
/Users/koic/src/github.com/jnunemaker/crack/lib/crack.rb:7:in `require'
         1: from
/Users/koic/src/github.com/jnunemaker/crack/lib/crack/xml.rb:1:in
`<top (required)>'
/Users/koic/src/github.com/jnunemaker/crack/lib/crack/xml.rb:1:in
`require': cannot load such file --
rexml/parsers/streamparser (LoadError)
```

This PR adds REXML to gem dependency.

## Other Information

The ruby-head of gems that depends on crack has failed.
e.g. https://circleci.com/gh/rubocop-hq/rubocop/81817

I hope a release that includes this change. Thank you!
