### PR TITLE
Ship LICENSE file with the gem

### DIFF
--- a/crack.gemspec
+++ b/crack.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/jnunemaker/crack"
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  gem.files         = `git ls-files -- lib/*`.split("\n")
+  gem.files         = `git ls-files -- lib/* LICENSE README.md History`.split("\n")
   gem.name          = "crack"
   gem.require_paths = ["lib"]
   gem.version       = Crack::VERSION


### PR DESCRIPTION
PR #61 removed not only test files, but also useful files, such as LICENSE file. This file is demanded by Linux distros such as Fedora.