### PR TITLE
Use named parameters for `safe_load`.

### DIFF
--- a/lib/crack/json.rb
+++ b/lib/crack/json.rb
@@ -13,7 +13,7 @@ module Crack
 
     def self.parse(json)
       yaml = unescape(convert_json_to_yaml(json))
-      YAML.safe_load(yaml, [Regexp, Date, Time])
+      YAML.safe_load(yaml, permitted_classes: [Regexp, Date, Time])
     rescue *parser_exceptions
       raise ParseError, "Invalid JSON string"
     rescue Psych::DisallowedClass


### PR DESCRIPTION
This is available since Psych 3.1 [[1], [2]], but mandatory since Psych 4.0 [[3]].

Of course the question is if this is acceptable with regard to backward compatibility, because if I am not mistaken Psych 3.1 was introduced in Ruby 2.6.

Fixes #72

[1]: https://github.com/ruby/psych/pull/358
[2]: https://github.com/ruby/psych/pull/378
[3]: https://github.com/ruby/psych/commit/0767227051dbddf1f949eef512c174deabf22891