### PR TITLE
Add BigDecimal to gem dependency

### DIFF
--- a/crack.gemspec
+++ b/crack.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |gem|
   gem.version       = Crack::VERSION
   gem.license       = "MIT"
 
+  gem.add_runtime_dependency("bigdecimal")
   gem.add_runtime_dependency("rexml")
 end


### PR DESCRIPTION
## Summary

BigDecimal gem has been bundled gem since Ruby 3.3.0-dev.

- https://bugs.ruby-lang.org/issues/19843
- https://github.com/ruby/ruby/commit/1c93288f8bbf667cb95eb7137b2fe64213894b77

So, this PR adds BigDecimal to runtime gem dependency.

## Other Information

The ruby-head of gems that depends on crack has warned:

```console
$ ruby -v
ruby 3.3.0dev (2023-08-22T14:46:32Z master 7127f39bac) [x86_64-darwin22]

$ cd path/to/rubocop/rubocop
$ bundle update
$ bundle exec rake spec
/Users/koic/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/crack-0.4.5/lib/crack/xml.rb:9: warning:
bigdecimal will be not part of the default gems since Ruby 3.4.0. Add it to your Gemfile.
```