### PR TITLE
Fix parse issue with consecutive dates

### DIFF
--- a/lib/crack/json.rb
+++ b/lib/crack/json.rb
@@ -100,9 +100,12 @@ module Crack
           (date_starts + date_ends).each { |i| output[i-1] = ' ' }
         else
           extra_chars_to_be_added = 0
+          timestamp_marker = '!!timestamp '
+          timestamp_marker_size = timestamp_marker.size
+
           date_starts.each do |i|
-            output[i-2+extra_chars_to_be_added] = '!!timestamp '
-            extra_chars_to_be_added += 10
+            output[i-2+extra_chars_to_be_added] = timestamp_marker
+            extra_chars_to_be_added += timestamp_marker_size - 1
           end
         end
       end

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -14,7 +14,7 @@ describe "JSON Parsing" do
     %({"a": "'", "b": "5,000"})                   => {"a" => "'", "b" => "5,000"},
     %({"a": "a's, b's and c's", "b": "5,000"})    => {"a" => "a's, b's and c's", "b" => "5,000"},
     %({"a": "2007-01-01"})                        => {'a' => Date.new(2007, 1, 1)},
-    %({"first_date": "2016-01-25", "second_date": "2014-01-26"}) => {'first_date' => Date.new(2016, 1, 25), 'second_date' => Date.new(2014, 1, 26)},
+    %({"first_date": "2016-01-25", "second_date": "2014-01-26", "third_date": "2024-01-02"}) => {'first_date' => Date.new(2016, 1, 25), 'second_date' => Date.new(2014, 1, 26), 'third_date' => Date.new(2024, 1, 2)},
     %({"first_date": "2016-01-25", "non_date": "Abc", "second_date": "2014-01-26"}) => {'first_date' => Date.new(2016, 1, 25), 'non_date' => 'Abc', 'second_date' => Date.new(2014, 1, 26)},
     %({"a": "2007-01-01 01:12:34 Z"})             => {'a' => Time.utc(2007, 1, 1, 1, 12, 34)},
     # Handle ISO 8601 date/time format http://en.wikipedia.org/wiki/ISO_8601


### PR DESCRIPTION
Closes #58 

The issue was with the offset used for `extra_chars_to_be_added`. The inserted string is 12 characters long, but the code incremented the offset by only 10 - it should have been 11 (we're replacing 1 char with 12 chars, 12 - 1 = 11).

Why wasn't it a problem? The `output` variable holds the json with _extra_ spaces added, so it had some space to "correct" itself.

```ruby
# `output` argument, note the double spaces
'{"first_date":  "2016-01-25",  "second_date":  "2014-01-26",  "third_date":  "2024-01-02"}'
# `output` after the first insert - looks okay
'{"first_date": !!timestamp "2016-01-25",  "second_date":  "2014-01-26",  "third_date":  "2024-01-02"}'
# `output` after the second insert - a bit off, but still valid
'{"first_date": !!timestamp "2016-01-25",  "second_date":!!timestamp  "2014-01-26",  "third_date":  "2024-01-02"}'
# `output` after the third insert - the extra keyword ate the `:` and the json is not valid anymore
'{"first_date": !!timestamp "2016-01-25",  "second_date":!!timestamp  "2014-01-26",  "third_date"!!timestamp   "2024-01-02"}'
```

There's a green pipeline using my other PR: https://github.com/kiskoza/crack/actions/runs/7386253493