### PR TITLE
New release

### DIFF
--- a/History
+++ b/History
@@ -1,3 +1,12 @@
+== 0.4.6 2024-01-29
+
+* minor patches
+  * Ruby 3.1, 3.2, 3.3 support
+  * Ship LICENSE file
+  * Add BidDecimal to gem dependency
+  * Move CI to Github Actions
+  * Fix parse issue with consecutive dates
+
 == 0.4.5 2020-12-26
 
 * 1 minor patch
@@ -28,7 +37,7 @@
 * 2 minor patches
   * Correct unnormalization of attribute values (der-flo)
   * Fix error in parsing YAML in the case where a hash value ends with backslashes, and there are subsequent values in the hash (deadprogrammer)
-  
+
 == 0.1.1 2009-03-31
 * 1 minor patch
   * Parsing empty or blank xml now returns empty hash instead of raising error.

--- a/History
+++ b/History
@@ -3,7 +3,7 @@
 * minor patches
   * Ruby 3.1, 3.2, 3.3 support
   * Ship LICENSE file
-  * Add BidDecimal to gem dependency
+  * Add BigDecimal to gem dependency
   * Move CI to Github Actions
   * Fix parse issue with consecutive dates
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,26 @@
 # crack
 
-[![Build Status](https://travis-ci.org/jnunemaker/crack.svg?branch=master)](https://travis-ci.org/jnunemaker/crack)
+[![Test](https://github.com/jnunemaker/crack/actions/workflows/test.yml/badge.svg)](https://github.com/jnunemaker/crack/actions/workflows/test.yml)
+[![Gem Version](https://badge.fury.io/rb/crack.svg)](https://badge.fury.io/rb/crack)
+![downloads](https://img.shields.io/gem/dt/crack?label=downloads)
 
 Really simple JSON and XML parsing, ripped from Merb and Rails. The XML parser is ripped from Merb and the JSON parser is ripped from Rails. I take no credit, just packaged them for all to enjoy and easily use.
 
 ## compatibility
 
-* ruby 1.8.7
-* ruby 1.9+ (3 failures related to time parsing, would love it if someone could figure them out)
+* Ruby 2.x
+* Ruby 3.x
 
 ## note on patches/pull requests
 
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it. This is important so I don't break it in a future version unintentionally.
-* `script/test` - this will bootstrap and run the tests
-* Commit, do not mess with rakefile, version, or history. (if you want to have your own version, that is fine but bump version in a commit by itself in another branch so I can ignore when I pull)
-* Send me a pull request. Bonus points for topic branches.
+* Run the tests with `rake test`
+* Open a Pull Request with the changes
 
 ## usage
-  
+
 ```ruby
 gem 'crack' # in Gemfile
 require 'crack' # for xml and json
@@ -28,7 +29,7 @@ require 'crack/xml' # for just xml
 ```
 
 ## examples
-  
+
 ```ruby
 Crack::XML.parse("<tag>This is the contents</tag>")
 # => {'tag' => 'This is the contents'}
@@ -40,7 +41,3 @@ Crack::JSON.parse('{"tag":"This is the contents"}')
 ## Copyright
 
 Copyright (c) 2009 John Nunemaker. See LICENSE for details.
-
-## Docs
-
-http://rdoc.info/projects/jnunemaker/crack

--- a/crack.gemspec
+++ b/crack.gemspec
@@ -1,20 +1,30 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/crack/version', __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('lib/crack/version', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["John Nunemaker"]
-  gem.email         = ["nunemaker@gmail.com"]
-  gem.description   = %q{Really simple JSON and XML parsing, ripped from Merb and Rails.}
-  gem.summary       = %q{Really simple JSON and XML parsing, ripped from Merb and Rails.}
-  gem.homepage      = "https://github.com/jnunemaker/crack"
+  gem.authors       = ['John Nunemaker']
+  gem.email         = ['nunemaker@gmail.com']
+  gem.description   = 'Really simple JSON and XML parsing, ripped from Merb and Rails.'
+  gem.summary       = 'Really simple JSON and XML parsing, ripped from Merb and Rails.'
+  gem.homepage      = 'https://github.com/jnunemaker/crack'
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.files         = `git ls-files -- lib/* LICENSE README.md History`.split("\n")
-  gem.name          = "crack"
-  gem.require_paths = ["lib"]
+  gem.name          = 'crack'
+  gem.require_paths = ['lib']
   gem.version       = Crack::VERSION
-  gem.license       = "MIT"
+  gem.license       = 'MIT'
 
-  gem.add_runtime_dependency("bigdecimal")
-  gem.add_runtime_dependency("rexml")
+  gem.metadata = {
+    'bug_tracker_uri' => 'https://github.com/jnunemaker/crack/issues',
+    'changelog_uri' => 'https://github.com/jnunemaker/crack/blob/master/History',
+    'source_code_uri' => 'https://github.com/jnunemaker/crack',
+    'rubygems_mfa_required' => 'true'
+  }
+
+  gem.required_ruby_version = '>= 2.0'
+
+  gem.add_runtime_dependency('bigdecimal')
+  gem.add_runtime_dependency('rexml')
 end

--- a/lib/crack.rb
+++ b/lib/crack.rb
@@ -2,6 +2,7 @@ module Crack
   class ParseError < StandardError; end
 end
 
+require 'crack/version'
 require 'crack/util'
 require 'crack/json'
 require 'crack/xml'

--- a/lib/crack/version.rb
+++ b/lib/crack/version.rb
@@ -1,3 +1,3 @@
 module Crack
-  VERSION = "0.4.5"
+  VERSION = "0.4.6"
 end


### PR DESCRIPTION
We already have a few fixes merged in, we should do a release soon to make sure that this gem remains usable.

ToDo:
* [x] Set up a CI to verify the code changes
* [x] Review open PRs and merge them if they make sense
* [x] Go through the open issues and verify if they are still a problem
* [x] Write a changelog in History
* [x] Refresh the readme
* [x] Bump version number
* [ ] Make a new tag and release the new version 

----

My Questions:

**Should we add a minimum Ruby version?**

I wasn't able to set up the environment for Ruby <2.0, and there are already EOL for ages.

**Should we release it as 1.0.0 as well?**

The gem seems to be really stable, but most of the gems / projects are referencing it as `~> 0.4.x`, so we definitely need a `0.4.6` first.
